### PR TITLE
fix: use a more robust type guard

### DIFF
--- a/src/namer.ts
+++ b/src/namer.ts
@@ -233,7 +233,7 @@ export class Namer {
    * @param props properties to over-ride the parent props
    */
   public addPrefix(prefix: Namer | string[], props?: NamerProps): Namer {
-    const p = prefix instanceof Namer ? prefix.parts : prefix;
+    const p = Array.isArray(prefix) ? prefix : prefix.parts;
     return new Namer([...p, ...this.parts], { ...this.props, ...props });
   }
 
@@ -243,7 +243,7 @@ export class Namer {
    * @param props properties to over-ride the parent props
    */
   public addSuffix(suffix: Namer | string[], props?: NamerProps): Namer {
-    const s = suffix instanceof Namer ? suffix.parts : suffix;
+    const s = Array.isArray(suffix) ? suffix : suffix.parts;
     return new Namer([...this.parts, ...s], { ...this.props, ...props });
   }
 


### PR DESCRIPTION
The problem is that when you start playing around with yarn link,
you might end up with multiple instances of the Namer class.

Error looks like:
```
/Users/ahammond/Documents/ClickUp/cold-storage-cdk/node_modules/multi-convention-namer/src/namer.ts:207
    return new Namer([...this.parts, ...s], { ...this.props, ...props });
                                        ^
TypeError: s is not iterable
    at Namer.addSuffix (/Users/ahammond/Documents/ClickUp/cold-storage-cdk/node_modules/multi-convention-namer/src/namer.ts:207:41)
```

Solution? Use `Array.isArray()` instead, since it's core.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.